### PR TITLE
Update to dogen 2.0.0

### DIFF
--- a/address-controller/image.yaml
+++ b/address-controller/image.yaml
@@ -1,10 +1,10 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-addresscontroller-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/server/bin/launch.sh"
 
@@ -13,7 +13,7 @@ packages:
 
 # TODO: Change to use product artifacts
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/server.tgz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/server.tgz
 
 scripts:
     - package: address-controller

--- a/broker/image.yaml
+++ b/broker/image.yaml
@@ -1,10 +1,9 @@
 # TODO: Set version from build server
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-broker-openshift
 from: jboss/openjdk18-rhel7:1.0
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
 user: 185
 
 cmd:
@@ -21,8 +20,8 @@ packages:
 
 # TODO: Use product built artifacts
 sources:    
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/artemis-image.tar
-    - url: http://www-eu.apache.org/dist/activemq/activemq-artemis/2.1.0/apache-artemis-2.1.0-bin.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/artemis-image.tar
+    - artifact: http://www-eu.apache.org/dist/activemq/activemq-artemis/2.1.0/apache-artemis-2.1.0-bin.tar.gz
 
 scripts:
     - package: artemis-image
@@ -31,13 +30,12 @@ scripts:
       exec: install      
 
 envs:
-    information:
-        - name: "ARTEMIS_HOME"
-          value: "/opt/apache-artemis-2.1.0"
-        - name: "PATH"
-          value: "$ARTEMIS_HOME/bin:$PATH"
-        - name: "DISTRO_NAME"
-          value: "apache-artemis-2.1.0"           
+    - name: "ARTEMIS_HOME"
+      value: "/opt/apache-artemis-2.1.0"
+    - name: "PATH"
+      value: "$ARTEMIS_HOME/bin:$PATH"
+    - name: "DISTRO_NAME"
+      value: "apache-artemis-2.1.0"           
 volumes: 
   - "/var/run/artemis"           
            

--- a/configserv/image.yaml
+++ b/configserv/image.yaml
@@ -1,14 +1,14 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-configserv-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/configserv/bin/launch.sh"
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/configserv.tgz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/configserv.tgz
            
 scripts:
     - package: configserv

--- a/console/image.yaml
+++ b/console/image.yaml
@@ -1,10 +1,10 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-console-openshift
 from: jboss-base-7/base:1.3
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "node"
     - "/opt/app-root/src/bin/console_server.js"
@@ -14,7 +14,7 @@ packages:
     - cyrus-sasl-lib
 
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/console-latest.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/console-latest.tar.gz
            
 scripts:    
     - package: console
@@ -25,11 +25,10 @@ scripts:
 
 
 envs:
-    information:
-        - name: "NODE_PATH"
-          value: "/usr/lib/node_modules"
-        - name: "DISTRO_NAME"
-          value: "console-latest"
+    - name: "NODE_PATH"
+      value: "/usr/lib/node_modules"
+    - name: "DISTRO_NAME"
+      value: "console-latest"
 ports:
     - value: 56720 
     - value: 8080

--- a/mqtt-gateway/image.yaml
+++ b/mqtt-gateway/image.yaml
@@ -1,14 +1,14 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-mqttgateway-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/mqtt-gateway/run_mqtt.sh"
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/mqtt-gateway-1.0-SNAPSHOT-bin.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/mqtt-gateway-1.0-SNAPSHOT-bin.tar.gz
            
 scripts:
     - package: mqtt-gateway
@@ -17,9 +17,8 @@ scripts:
       exec: install
       
 envs:
-    information:
-        - name: "DISTRO_NAME"
-          value: "mqtt-gateway-1.0-SNAPSHOT-bin"
+    - name: "DISTRO_NAME"
+      value: "mqtt-gateway-1.0-SNAPSHOT-bin"
 
 ports:
     - value: 1883 

--- a/mqtt-lwt/image.yaml
+++ b/mqtt-lwt/image.yaml
@@ -1,18 +1,17 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-mqttlwt-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/mqtt-lwt/run_mqtt.sh"
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/mqtt-lwt-1.0-SNAPSHOT-bin.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/mqtt-lwt-1.0-SNAPSHOT-bin.tar.gz
 envs:
-    information:
-        - name: "DISTRO_NAME"
-          value: "mqtt-lwt-1.0-SNAPSHOT-bin"
+    - name: "DISTRO_NAME"
+      value: "mqtt-lwt-1.0-SNAPSHOT-bin"
 scripts:
     - package: mqtt-lwt
       exec: install

--- a/qdrouterd/image.yaml
+++ b/qdrouterd/image.yaml
@@ -1,10 +1,10 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-interconnect-openshift
 from: jboss-amqmaas-1-tech-preview/amqmaas10-qpidproton-openshift:latest
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/etc/qpid-dispatch/run_qdr.sh"
     
@@ -14,7 +14,7 @@ packages:
     - iputils
     
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/qpid-dispatch-image.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/qpid-dispatch-image.tar.gz
 
 scripts:
     - package: qdrouterd

--- a/qpid-proton/image.yaml
+++ b/qpid-proton/image.yaml
@@ -1,10 +1,10 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-qpidproton-openshift
 from: jboss-base-7/base:1.3
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "bash"
 

--- a/queue-scheduler/image.yaml
+++ b/queue-scheduler/image.yaml
@@ -1,14 +1,14 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-queuescheduler-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/queue-scheduler/bin/launch.sh"
 sources:
-   - url: https://dl.bintray.com/enmasse/snapshots/latest/queue-scheduler.tgz
+   - artifact: https://dl.bintray.com/enmasse/snapshots/latest/queue-scheduler.tgz
            
 scripts:
     - package: queue-scheduler

--- a/router-agent/image.yaml
+++ b/router-agent/image.yaml
@@ -1,16 +1,16 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-routeragent-openshift
 from: jboss-base-7/base:1.3
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "node"
     - "/opt/app-root/src/ragent.js"
 
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/ragent-latest.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/ragent-latest.tar.gz
 packages:
     - npm
     - nodejs
@@ -20,10 +20,9 @@ scripts:
       exec: install
 
 envs:
-    information:
-        - name: "NODE_PATH"
-          value: "/usr/lib/node_modules"
-        - name: "DISTRO_NAME"
-          value: "ragent-latest"           
+    - name: "NODE_PATH"
+      value: "/usr/lib/node_modules"
+    - name: "DISTRO_NAME"
+      value: "ragent-latest"           
 ports:
     - value: 55672

--- a/router-metrics/image.yaml
+++ b/router-metrics/image.yaml
@@ -1,16 +1,16 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-routermetrics-openshift
 from: jboss-amqmaas-1-tech-preview/amqmaas10-qpidproton-openshift:latest
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "python"
     - "/opt/router-metrics.py"
 
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/router-metrics.py
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/router-metrics.py
            
 scripts:    
     - package: router-metrics

--- a/subscription-service/image.yaml
+++ b/subscription-service/image.yaml
@@ -1,10 +1,10 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-subscriptionservice-openshift
 from: jboss-base-7/base:1.3
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "node"
     - "/opt/app-root/src/subserv.js"
@@ -13,17 +13,16 @@ packages:
     - nodejs
 
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/subserv-latest.tar.gz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/subserv-latest.tar.gz
            
 scripts:    
     - package: subscription-service
       exec: install
 
 envs:
-    information:
-        - name: "NODE_PATH"
-          value: "/usr/lib/node_modules"
-        - name: "DISTRO_NAME"
-          value: "subserv-latest"
+    - name: "NODE_PATH"
+      value: "/usr/lib/node_modules"
+    - name: "DISTRO_NAME"
+      value: "subserv-latest"
 ports:
     - value: 5672

--- a/topic-forwarder/image.yaml
+++ b/topic-forwarder/image.yaml
@@ -1,14 +1,14 @@
-version: latest
-release: dev
+version: 1.0
 name: jboss-amqmaas-1-tech-preview/amqmaas10-topicforwarder-openshift
 from: jboss/openjdk18-rhel7:1.0
 user: 185
 dogen:
-    version: "2.0.0rc15"
+    version: "2.0.0"
+    ssl_verify: false
 cmd:
     - "/opt/topic-forwarder/bin/launch.sh"
 sources:
-    - url: https://dl.bintray.com/enmasse/snapshots/latest/topic-forwarder.tgz
+    - artifact: https://dl.bintray.com/enmasse/snapshots/latest/topic-forwarder.tgz
            
 scripts:
     - package: topic-fowarder
@@ -16,6 +16,5 @@ scripts:
     - package: dynamic-resources
       exec: install 
 envs:
-    information:
-        - name: "JAVA_HOME"
-          value: "/usr/lib/jvm/java"
+    - name: "JAVA_HOME"
+      value: "/usr/lib/jvm/java"


### PR DESCRIPTION
Additionally:

1. Remove the release key - not used/required
2. Change url to artifact in sources
3. Do not verify SSL - doesn't work with Akamai redirects
4. Change version to 1.0
5. Update envs section to follow new format